### PR TITLE
Pre-launch hardening: noise-aware AML gate, stratified finetune val, arm (e), CI + packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,26 @@ jobs:
           -x
           --durations=10
 
+  tests:
+    # The full test suite — the `quality` job above runs only a fast smoke subset,
+    # so unit tests for finetuner / uplift / multitask / inference would otherwise
+    # never run in CI. This job closes that coverage gap.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install (CPU torch)
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -e ".[dev,serve]"
+      - name: Full pytest
+        run: pytest tests/ -q --durations=15
+
   python-compat:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ secrets/
 
 # Local-only design spec
 docs/SPEC.md
+
+# Local-only copy of the inspiration paper (not redistributable)
+/paper/

--- a/pragmatiq/cli.py
+++ b/pragmatiq/cli.py
@@ -99,12 +99,13 @@ def probe_cmd(
     label: Path = typer.Option(..., help="Label parquet (labels/<task>.parquet)."),
     device: str = typer.Option("auto", help="auto | cpu | cuda."),
     probe_model: str = typer.Option("gbdt", help="Probe head: gbdt | logistic | lightgbm."),
+    seed: int = typer.Option(0, help="Probe random seed (for reproducible AUCs)."),
 ) -> None:
     """Probe a trained model on a label table; reports ROC-AUC + PR-AUC vs baseline."""
     from pragmatiq import api
 
     typer.echo(json.dumps(
-        api.probe(shard_dir, run, label, device=device, probe_model=probe_model), indent=2))
+        api.probe(shard_dir, run, label, device=device, probe_model=probe_model, seed=seed), indent=2))
 
 
 @app.command("uplift")

--- a/pragmatiq/models/gnn.py
+++ b/pragmatiq/models/gnn.py
@@ -224,6 +224,20 @@ def _class_weights(y: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
     return torch.tensor([1.0, neg / pos], dtype=torch.float32)
 
 
+def _significant_margin(xs: list[float], ys: list[float], floor: float = 0.01) -> bool:
+    """Whether arm ``xs`` beats arm ``ys`` by more than the cross-seed noise.
+
+    Gates on the mean of the *paired* per-seed difference exceeding BOTH ``floor``
+    and the cross-seed std of that difference — a noise-aware replacement for a
+    fixed margin. A fixed 0.01 could clear a gap that sits inside the per-seed
+    noise band (observed: a world seed where c−d = 0.016 with std 0.014), which
+    makes the gate flip with the seed. With a single seed the std is 0 and this
+    reduces to ``mean > floor``.
+    """
+    d = np.asarray(xs, dtype=float) - np.asarray(ys, dtype=float)
+    return bool(d.mean() > max(floor, float(d.std())))
+
+
 def _fit_gnn(graph: TransferGraph, seed: int, train_mask: torch.Tensor, val_mask: torch.Tensor,
              test_mask: torch.Tensor, epochs: int = 80, hidden: int = 128, n_layers: int = 2,
              lr: float = 1e-2, patience: int = 4, eval_every: int = 5) -> float:
@@ -312,6 +326,9 @@ def aml_results_markdown(res: dict[str, Any]) -> str:
     if "d_lr_handcrafted" in ps:
         rows.append(("(d) control: logistic regression on the same hand-crafted features, no graph",
                      ps["d_lr_handcrafted"]))
+    if "e_gnn_topology" in ps:
+        rows.append(("(e) control: GraphSAGE on topology-only (degree) features, no amount/volume",
+                     ps["e_gnn_topology"]))
     lines = ["| setup | ROC-AUC (mean ± std over seeds) |", "| --- | --- |"]
     lines += [f"| {name} | {m['mean']:.3f} ± {m['std']:.3f} |" for name, m in rows]
     v = res["verdict"]
@@ -320,7 +337,8 @@ def aml_results_markdown(res: dict[str, Any]) -> str:
     lines.append(
         f"**Relational recovery (gated): {v['pass']}** — a GraphSAGE over the transfer graph recovers "
         f"money-mule rings that a probe on isolated pragmatiq embeddings cannot ((c) > (a) = "
-        f"{v['c_beats_a']}), so the AML signal lives in the multi-hop transfer structure an isolated "
+        f"{v.get('graph_recovers_signal', v['c_beats_a'])}), so the AML signal lives in the multi-hop "
+        f"transfer structure an isolated "
         f"per-user embedding misses. Money mules are degree- and volume-matched to ordinary accounts, "
         f"so the signal is the multi-hop layering chain, not 1-hop degree, and message passing adds over "
         f"the same features without a graph ((c) > (d) = {mp}). The gate requires both."
@@ -403,7 +421,7 @@ def run_aml_ablation(
     epochs: int = 150,
     gnn_layers: int = 3,
 ) -> dict[str, Any]:
-    """The four-arm AML comparison (a: isolated, b: GNN+pragmatiq, c: GNN+handcrafted, d: LR control).
+    """The AML ablation (a: isolated, b: GNN+pragmatiq, c: GNN+handcrafted, d: LR control, e: GNN topology-only).
 
     Returns mean/std AUC per setup over ``seeds`` plus a verdict. The gated claim is
     *relational recovery* — ``c > a`` (a graph over the transfer structure recovers
@@ -448,9 +466,16 @@ def _run_aml_ablation(
     hand = handcrafted_node_features(transfers_path, user_ids)
     hand_graph = TransferGraph(x=torch.from_numpy(hand).float(), edge_index=pragma_graph.edge_index,
                                edge_attr=pragma_graph.edge_attr, y=pragma_graph.y, user_ids=user_ids)
+    # Arm (e), topology-only control: the SAME graph but node features reduced to
+    # degree only (in/out/total), dropping the amount/volume columns. It isolates
+    # what adjacency + message passing alone recover from the rings, separate from
+    # transfer-amount/recency signal. SPEC Phase 6 (e); reported, not gated.
+    hand_topo = hand[:, :3]
+    topo_graph = TransferGraph(x=torch.from_numpy(hand_topo).float(), edge_index=pragma_graph.edge_index,
+                               edge_attr=pragma_graph.edge_attr, y=pragma_graph.y, user_ids=user_ids)
 
-    res: dict[str, list[float]] = {"a_isolated": [], "b_gnn_pragma": [],
-                                   "c_gnn_handcrafted": [], "d_lr_handcrafted": []}
+    res: dict[str, list[float]] = {"a_isolated": [], "b_gnn_pragma": [], "c_gnn_handcrafted": [],
+                                   "d_lr_handcrafted": [], "e_gnn_topology": []}
     for s in seeds:
         # one stratified split per seed, shared by all arms (fair comparison);
         # model selection uses the val mask, test is scored exactly once
@@ -463,6 +488,8 @@ def _run_aml_ablation(
         # control arm: SAME handcrafted features, NO message passing — isolates
         # what graph propagation itself contributes over the raw features
         res["d_lr_handcrafted"].append(_fit_mlp(hand, y, train_mask, test_mask))
+        res["e_gnn_topology"].append(_fit_gnn(topo_graph, s, train_mask, val_mask, test_mask,
+                                              epochs=epochs, n_layers=gnn_layers))
 
     def ms(v: list[float]) -> dict[str, float]:
         a = np.array(v)
@@ -472,7 +499,6 @@ def _run_aml_ablation(
     a = summary["a_isolated"]["mean"]
     b = summary["b_gnn_pragma"]["mean"]
     c = summary["c_gnn_handcrafted"]["mean"]
-    d = summary["d_lr_handcrafted"]["mean"]
     # The gated claim is relational recovery: a GraphSAGE over the transfer graph
     # recovers money-mule rings that an isolated probe on the same features misses
     # (c > a), and message passing adds over the same features without a graph
@@ -487,7 +513,12 @@ def _run_aml_ablation(
     #    beating hand-crafted features) is REPORTED, not gated — see the verdict.
     # The control arm (d) checks the graph effect is real: (c) > (d) means message
     # passing adds over the same hand-crafted features without a graph.
-    margin = 0.01
+    margin = 0.01  # reported (not gated) booleans keep a small fixed margin
+    # Gated claims are noise-aware: the mean gap must exceed the cross-seed std of
+    # the per-seed paired difference, not a fixed 0.01 that a gap inside the noise
+    # band could clear (observed: a world seed with c−d = 0.016 at std 0.014).
+    graph_recovers_signal = _significant_margin(res["c_gnn_handcrafted"], res["a_isolated"])
+    message_passing_adds = _significant_margin(res["c_gnn_handcrafted"], res["d_lr_handcrafted"])
     return {
         "per_setup": summary, "raw": res,
         "n_nodes": pragma_graph.num_nodes, "n_edges": int(pragma_graph.edge_index.shape[1]),
@@ -498,18 +529,21 @@ def _run_aml_ablation(
             "b_beats_c": b > c + margin,
             "c_beats_a": c > a + margin,
             "c_between_a_and_b": a <= c <= b,
-            "message_passing_adds": c > d + margin,
-            # Relational recovery: a graph over the transfer structure beats a
-            # probe on the isolated per-user embedding (c > a), so the AML signal
-            # lives in the multi-hop transfer structure an isolated embedding misses.
-            "graph_recovers_signal": c > a + margin,
-            # The learned-embedding headline — the per-user embedding + graph beats
-            # both the isolated probe and the hand-crafted-feature graph (b > a and
-            # b > c), (c) between — is reported, not gated: on this synthetic book
-            # the per-user embedding does not recover the multi-hop signal on its own.
+            # Relational recovery (gated): a GraphSAGE over the transfer structure
+            # beats a probe on the isolated per-user embedding (c > a), and message
+            # passing adds over the same features without a graph (c > d) — each by
+            # more than the cross-seed noise.
+            "graph_recovers_signal": graph_recovers_signal,
+            "message_passing_adds": message_passing_adds,
+            # Arm (e), reported not gated: does topology (degree) + message passing
+            # alone recover the rings over the isolated probe, without amount/volume?
+            "topology_only_recovers": _significant_margin(res["e_gnn_topology"], res["a_isolated"]),
+            # The learned-embedding headline (b > a and b > c, (c) between) is
+            # reported, not gated: on this synthetic book the per-user embedding does
+            # not recover the multi-hop signal on its own.
             "paper_ordering": (b > a + margin) and (b > c + margin) and (a <= c <= b),
-            # The gated claim is the relational mechanism: recovery (c > a) plus
+            # The gate is the relational mechanism: noise-aware recovery (c > a) plus
             # message passing adding over the same features without a graph (c > d).
-            "pass": (c > a + margin) and (c > d + margin),
+            "pass": graph_recovers_signal and message_passing_adds,
         },
     }

--- a/pragmatiq/training/finetuner.py
+++ b/pragmatiq/training/finetuner.py
@@ -28,6 +28,33 @@ from .probe import _load_label_table, cutoffs_from_labels
 log = logging.getLogger(__name__)
 
 
+def _stratified_split(
+    users: list[str], labels: dict[str, int], val_fraction: float, seed: int
+) -> tuple[set[str], set[str]]:
+    """Partition ``users`` into ``(train, val)`` sets, stratified by label.
+
+    Splitting each class proportionally keeps both classes in the validation set
+    when the data allows. An unstratified shuffle-and-slice can leave the val
+    split single-class for rare labels (fraud/aml) — which makes the held-out
+    ROC-AUC NaN, so ``best_val_auc`` stays at the ``-1.0`` sentinel and the
+    last-epoch (not best) model is silently kept. At least one user per present
+    class is held out for val whenever that class has more than one member.
+    """
+    rng = np.random.default_rng(seed)
+    by_cls: dict[int, list[str]] = {}
+    for u in users:
+        by_cls.setdefault(int(labels[u]), []).append(u)
+    val: set[str] = set()
+    for members in by_cls.values():
+        members = list(members)
+        rng.shuffle(members)
+        # Cap at len-1 so at least one member of each class stays in train (a
+        # high val_fraction on a tiny class must not empty that class from train).
+        n_val = min(len(members) - 1, max(1, int(round(len(members) * val_fraction)))) if len(members) > 1 else 0
+        val.update(members[:n_val])
+    return set(users) - val, val
+
+
 @dataclass
 class FineTuneConfig:
     """Hyperparameters for LoRA fine-tuning."""
@@ -75,10 +102,9 @@ class LoRAFineTuner:
         self._cutoffs = cutoffs_from_labels(uids, eval_us)
         have = {u: int(lab) for u, lab in zip(uids, labels) if u in set(dataset.index.order)}
         users = list(have)
-        rng = np.random.default_rng(self.config.seed)
-        rng.shuffle(users)
-        n_val = max(1, int(len(users) * self.config.val_fraction))
-        val_users, train_users = set(users[:n_val]), set(users[n_val:])
+        # Stratify the val split by label so rare-positive tasks keep both classes
+        # held out (else val ROC-AUC is NaN and the last-epoch model is kept).
+        train_users, val_users = _stratified_split(users, have, self.config.val_fraction, self.config.seed)
         label_of = have
 
         opt = torch.optim.AdamW(self._trainable(), lr=self.config.lr,

--- a/pragmatiq/training/probe.py
+++ b/pragmatiq/training/probe.py
@@ -152,8 +152,13 @@ def build_probe_classifier(model: str, seed: int, max_iter: int = 1000, C: float
 
         return HistGradientBoostingClassifier(random_state=seed), False
     if model == "lightgbm":
-        from lightgbm import LGBMClassifier
-
+        try:
+            from lightgbm import LGBMClassifier
+        except ImportError as exc:  # optional dependency, shipped in the [gbdt] extra
+            raise ImportError(
+                "probe_model='lightgbm' needs the optional extra: pip install 'pragmatiq[gbdt]'. "
+                "The default probe_model='gbdt' (sklearn HistGradientBoosting) needs no extra."
+            ) from exc
         return LGBMClassifier(random_state=seed, verbosity=-1), False
     if model == "logistic":
         from sklearn.linear_model import LogisticRegression

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "omegaconf>=2.3",
     "pyyaml>=6.0",
     "scikit-learn>=1.3",
-    "lightgbm>=4.0",
     "torch-geometric>=2.4",
     "lightning>=2.2",
     "matplotlib>=3.9",
@@ -44,12 +43,14 @@ dependencies = [
 [project.optional-dependencies]
 # Serving / export, the Streamlit demo, and a single `extras` group for the
 # frozen text encoder and experiment tracking. `full` pulls them all; `dev` is
-# the contributor toolchain. The gradient-boosting probe and the AML GNN need no
-# extra — they are part of the core install.
+# the contributor toolchain. The DEFAULT gradient-boosting probe (sklearn
+# HistGradientBoosting) and the AML GNN need no extra — they are core. The
+# optional `gbdt` extra only adds LightGBM for `probe_model="lightgbm"`.
 serve = ["onnx>=1.16", "onnxscript>=0.1", "onnxruntime>=1.18", "tritonclient[http]>=2.40"]
 demo = ["streamlit>=1.30", "plotly>=5.18"]
 extras = ["transformers>=4.40", "wandb>=0.16", "tensorboard>=2.16"]
-full = ["pragmatiq[serve,demo,extras]"]
+gbdt = ["lightgbm>=4.0"]
+full = ["pragmatiq[serve,demo,extras,gbdt]"]
 dev = ["pytest>=7.4", "pytest-cov", "ruff>=0.4", "mypy>=1.8", "types-PyYAML"]
 
 [project.scripts]

--- a/tests/test_finetuner.py
+++ b/tests/test_finetuner.py
@@ -127,3 +127,33 @@ def test_custom_head_resolved_for_finetune() -> None:
     ft = LoRAFineTuner(model, FineTuneConfig(head="ranking_test", n_classes=3, lora_rank=4))
     assert isinstance(ft.head, RankingTestHead)
     assert ft.head.net.out_features == 3  # head built at the configured n_classes
+
+
+def test_stratified_val_split_keeps_both_classes_for_rare_labels() -> None:
+    """A rare-positive label table must yield a val split with both classes.
+
+    An unstratified shuffle+slice can put all (or zero) positives on one side,
+    leaving the held-out val single-class -> roc_auc is NaN -> best_val_auc stays
+    -1.0 and the LAST-epoch (not best) model is returned. Stratifying prevents it.
+    """
+    from pragmatiq.training.finetuner import _stratified_split
+
+    # 40 users, only 4 positives: a 25% unstratified val could easily miss all 4.
+    labels = {f"u{i}": (1 if i < 4 else 0) for i in range(40)}
+    users = list(labels)
+    train, val = _stratified_split(users, labels, val_fraction=0.25, seed=0)
+    assert sum(labels[u] for u in val) >= 1, "val split has no positives (not stratified)"
+    assert any(labels[u] == 0 for u in val), "val split has no negatives"
+    assert train.isdisjoint(val) and (train | val) == set(users), "split must partition users"
+
+
+def test_stratified_split_never_empties_a_train_class() -> None:
+    """A small class with a high val_fraction must still leave a member in train,
+    or the backbone never sees that class during fine-tuning (n_val capped at len-1)."""
+    from pragmatiq.training.finetuner import _stratified_split
+
+    labels = {f"u{i}": (1 if i < 2 else 0) for i in range(10)}  # only 2 positives
+    train, val = _stratified_split(list(labels), labels, val_fraction=0.8, seed=0)
+    assert sum(labels[u] for u in train) >= 1, "train lost its only positives"
+    assert sum(labels[u] for u in val) >= 1, "val lost its only positives"
+    assert any(labels[u] == 0 for u in train), "train lost its negatives"

--- a/tests/test_gnn.py
+++ b/tests/test_gnn.py
@@ -144,9 +144,10 @@ class TestAblationPlumbing:
         emb = _fake_embeddings(list(labels), dim=24)
         res = run_aml_ablation(dataset / "transfers.parquet", emb, labels, seeds=(0,), epochs=20)
         assert set(res["per_setup"]) == {"a_isolated", "b_gnn_pragma", "c_gnn_handcrafted",
-                                         "d_lr_handcrafted"}
+                                         "d_lr_handcrafted", "e_gnn_topology"}
         assert "verdict" in res and "pass" in res["verdict"]
         assert "message_passing_adds" in res["verdict"]  # no-graph control arm
+        assert "topology_only_recovers" in res["verdict"]  # arm (e) topology-only diagnostic
         for setup in res["per_setup"].values():
             assert 0.0 <= setup["mean"] <= 1.0
 
@@ -211,3 +212,41 @@ class TestAblationPlumbing:
         }
         write_aml_report(small, readme_path=readme, notebook_path=None)
         assert "full-scale table" in readme.read_text(), "CI-scale must not clobber full-scale"
+
+
+class TestGateMargin:
+    """The gate-6 relational-recovery margin must be noise-aware, not a fixed 0.01."""
+
+    def test_significant_margin_is_noise_aware(self) -> None:
+        from pragmatiq.models.gnn import _significant_margin
+
+        # Clearly separated, low cross-seed variance -> significant.
+        assert _significant_margin([0.67, 0.66, 0.68], [0.60, 0.59, 0.61]) is True
+        # Positive mean difference (~0.01) but swamped by cross-seed std (~0.06):
+        # the old fixed-0.01 gate passes this; a noise-aware gate must reject it.
+        assert _significant_margin([0.61, 0.55, 0.58], [0.59, 0.62, 0.50]) is False
+        # Tiny margin below the floor even with zero variance -> rejected.
+        assert _significant_margin([0.505, 0.505], [0.500, 0.500]) is False
+
+    def test_markdown_cites_the_gated_noise_aware_flag(self) -> None:
+        """The 'Relational recovery (gated)' line must print graph_recovers_signal
+        (the noise-aware paired-seed test the gate uses), not c_beats_a (the fixed
+        0.01 mean-margin reported flag), so the narrative matches the actual gate."""
+        from pragmatiq.models.gnn import aml_results_markdown
+
+        res = {
+            "per_setup": {"a_isolated": {"mean": 0.60, "std": 0.05},
+                          "b_gnn_pragma": {"mean": 0.61, "std": 0.05},
+                          "c_gnn_handcrafted": {"mean": 0.62, "std": 0.05},
+                          "d_lr_handcrafted": {"mean": 0.59, "std": 0.05}},
+            "raw": {"a_isolated": [0.6]},
+            # Divergent on purpose: the fixed-margin c_beats_a is True, but the
+            # noise-aware gate (graph_recovers_signal) is False.
+            "verdict": {"pass": False, "c_beats_a": True, "graph_recovers_signal": False,
+                        "message_passing_adds": False, "b_beats_a": False, "b_beats_c": False,
+                        "paper_ordering": False},
+            "n_nodes": 100, "n_mules": 5, "n_edges": 40, "seeds": [0, 1, 2], "epochs": 10,
+        }
+        md = aml_results_markdown(res)
+        assert "(c) > (a) = False" in md, "markdown must cite the gated noise-aware flag"
+        assert "(c) > (a) = True" not in md


### PR DESCRIPTION
## Summary

Surgical fixes surfaced by the pre-launch validation (code/CPU/CI audit + a full-scale GPU run). The audit verdict was **clean** — no P0/P1 correctness bugs. These changes address the remaining P2/P3 items. No change to model architecture, tokenizer, training, or serving behavior.

## Changes
- **Noise-aware AML gate** (`models/gnn.py`): the gate-6 relational-recovery claim now requires the mean paired per-seed difference to exceed the cross-seed std, replacing a fixed `0.01` margin a within-noise gap could clear (observed: a world seed with `c−d = 0.016` at std `0.014`).
- **AML ablation arm (e)** (`models/gnn.py`): topology-only (degree) GraphSAGE control — SPEC Phase 6's fifth arm, reported (not gated), isolating adjacency + message passing from transfer amount/volume signal.
- **Stratified finetuner val split** (`training/finetuner.py`): rare-positive tasks (fraud/aml) could land a single-class val split → NaN AUC → last-epoch model + `-1.0` sentinel. Now stratified by label.
- **LightGBM → `[gbdt]` extra** (`pyproject.toml`, `training/probe.py`): the default probe is sklearn `HistGradientBoosting`; LightGBM is opt-in (`pip install 'pragmatiq[gbdt]'`) with an actionable error. Aligns packaging with the existing `api.probe` docstring.
- **`probe --seed`** (`cli.py`): reproducible probe AUCs from the CLI.
- **Full-pytest CI job** (`.github/workflows/ci.yml`): the `quality` job ran only a smoke subset; finetuner/uplift/multitask/inference unit tests now run in CI.

## Verification
- `ruff` ✅ · `mypy` ✅ · **full suite 300 passed / 1 skipped** (CUDA-only skip)
- `gate_6` still green at CI scale with the noise-aware gate (`pass=true`); arm (e) reports `topology_only_recovers`
- `docs_drift_check.py` in sync
- Full-scale GPU run separately confirmed flash-attn ≡ reference, bf16 training, and probe `0.653` > `0.468` baseline

## Notes
- Published README/MODEL_CARD AML tables show 4 arms (a–d); they'll gain the (e) row when regenerated on the next full `gate_6` write-results run. The 4-arm numbers remain accurate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly evaluation gates, validation splits, CI coverage, and optional dependencies; core training and serving paths are unchanged per the PR scope.
> 
> **Overview**
> Pre-launch hardening across CI, AML evaluation, fine-tuning, and packaging—no model architecture or training-path changes.
> 
> **CI** adds a separate `tests` job that runs the full `pytest tests/` suite so finetuner, uplift, multitask, and inference tests are not limited to the smoke subset in `quality`.
> 
> **AML GNN ablation** replaces the fixed `0.01` gate margin with `_significant_margin` (paired per-seed mean gap must beat both a floor and cross-seed std). Adds arm **(e)**—GraphSAGE on degree-only features—and verdict fields `topology_only_recovers` plus markdown that cites `graph_recovers_signal` for the gated narrative.
> 
> **LoRA fine-tuning** swaps random val slicing for label-stratified `_stratified_split` so rare-positive tasks keep both classes in validation and early stopping can pick a real best checkpoint.
> 
> **Packaging / probe**: LightGBM moves from core deps to optional `[gbdt]` with a clear import error; CLI `probe` gains `--seed` for reproducible AUCs.
> 
> **.gitignore** ignores local `/paper/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09f9d2f9f10050afce6bb2f13c8b25fc0c36a757. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->