### PR TITLE
docs: add "Run pragmatiq on AWS" end-to-end tutorial

### DIFF
--- a/website/content/docs/tutorials/aws.mdx
+++ b/website/content/docs/tutorials/aws.mdx
@@ -1,0 +1,367 @@
+---
+title: Run pragmatiq on AWS
+description: End-to-end on AWS — train the pragmatiq banking foundation model on an EC2 GPU instance with the AWS Deep Learning AMI, push artifacts to S3, then serve embeddings with NVIDIA Triton on an Amazon SageMaker real-time endpoint.
+---
+
+> pragmatiq is an independent implementation inspired by the PRAGMA paper
+> ([arXiv 2604.08649](https://arxiv.org/abs/2604.08649)) and is not affiliated with or endorsed by Revolut.
+
+This guide runs the **whole pragmatiq pipeline on AWS**, in two phases:
+
+1. **Train on EC2** — launch a single GPU instance from the [AWS Deep Learning AMI](https://docs.aws.amazon.com/dlami/latest/devguide/), generate data, tokenize, pretrain, embed, probe, fine-tune, and run the AML graph ablation; stage every artifact to **Amazon S3**.
+2. **Serve on SageMaker** — package the production **NVIDIA Triton** model and deploy it as an **Amazon SageMaker real-time endpoint** that returns user embeddings over HTTPS.
+
+It mirrors the local [Pretrain](/docs/tutorials/pretrain) and [Serve with Triton](/docs/tutorials/serve) tutorials — same commands, same Triton request shape — just on AWS-managed infrastructure. pragmatiq is **CPU-first**, so you can rehearse the entire flow on a CPU instance before paying for a GPU.
+
+<Callout type="info" title="Dynamiq is an AWS Partner">
+If you're standing this up on AWS at scale — multi-GPU training, SageMaker pipelines, or wiring
+embeddings into a feature store — [we can help](https://getdynamiq.ai). The steps below are
+self-serve and use only standard AWS services.
+</Callout>
+
+## How pragmatiq works — a foundation model for events, not text
+
+A large language model reads a stream of **subword tokens** and predicts the next one. pragmatiq reads a stream of **timestamped key–value events** — a card payment, an app screen, a transfer — and learns to reconstruct masked fields. It's the same transformer backbone, but because the input isn't text, three things change: the **tokenizer**, the notion of **position**, and the **training objective**.
+
+| | Text LLM | pragmatiq |
+| --- | --- | --- |
+| Unit | a subword piece | one `(key, value, time)` triple per field |
+| Tokenizer | BPE over a text corpus | per-field: numeric → percentile bins, categorical → id, text → BPE or a frozen-embedding sentinel |
+| Vocabulary | ~50–250k subwords | ~28k: key tokens + value buckets/ids + specials |
+| Position | integer index (1st, 2nd, 3rd token) | **continuous elapsed time** via TimeRoPE |
+| Sequence | one flat stream | a hierarchy: fields → events → history, plus a profile state |
+| Objective | next-/masked-token over the vocab | masked-value reconstruction from a 3-view head; MSE for text in the Nemotron variant |
+
+Click through the stack — every stage is implemented in `pragmatiq/models/`:
+
+<ArchitectureExplorer />
+
+### The tokenizer: key–value–time, not subwords
+
+A text tokenizer has one job: split a string into subword ids. pragmatiq's tokenizer fits **one vocabulary over the whole dataset** and turns each field into a key token plus a value representation chosen by the field's *kind* — keys and values share one embedding space:
+
+- **Numeric** values (amounts, balances) are **percentile-binned** with a dedicated **zero bucket**, so "no balance" is its own symbol and an unseen magnitude clips into the end buckets instead of failing.
+- **Low-cardinality strings** (country, channel) become **one categorical token** per value.
+- **High-cardinality text** (merchant names, device ids) is byte-level **BPE** by default — or, in the [Nemotron variant](#the-nemotron-variant), a single sentinel token whose raw string a frozen text model maps to a vector.
+
+Unseen keys or values at inference map to `[UNK]` with a warning — the model never raises on vocabulary drift, which matters when you serve a live book.
+
+<TokenizationWalkthrough />
+
+### Time is the spine, not an afterthought
+
+Banking events are wildly irregular — seconds apart, then months apart — so an integer position ("the previous event") throws away the strongest signal. pragmatiq compresses elapsed seconds with a log curve:
+
+$$
+\tau(\Delta t) = 8 \cdot \ln\!\left(1 + \frac{\Delta t}{8}\right)
+$$
+
+and feeds that as a **continuous position for rotary embeddings (TimeRoPE)** — a token at log-seconds $p$ rotates frequency pair $i$ by $p \cdot \text{inv\_freq}_i$, so attention encodes the *elapsed time between two events* rather than their ordinal distance. Calendar features (hour, day-of-week, day-of-month) take a separate sin/cos → MLP path, so day/night and weekday/weekend structure is available independently of elapsed time.
+
+<DecisionCard
+  title="RoPE over a continuous time position, not token index"
+  why="'One second ago' and 'one month ago' must be genuinely different relative rotations — integer positions can't express that, and elapsed time is the dominant signal in a banking history."
+  alternative="Standard integer-position RoPE or learned absolute positions, which treat 'the previous event' identically regardless of elapsed time."
+/>
+
+### Why the encoder stack differs from a vanilla transformer
+
+Rather than one flat sequence, pragmatiq encodes a **hierarchy** so an event's fields don't bleed across event boundaries:
+
+1. The **event encoder** encodes each event independently (block-diagonal attention within an event, a prepended `[EVT]` marker); its output plus calendar features is the per-event vector.
+2. The **profile-state encoder** encodes static attributes + lifelong milestones under a `[USR]` marker.
+3. The **history encoder** runs over `[profile, event…]` with TimeRoPE on log-seconds-to-the-latest-event; the `[USR]` slot output **is the user embedding**.
+
+All three are bidirectional, pre-norm, GELU, `ffn = 4d` — and the whole batch is packed **without padding** via `cu_seqlens` (flash-attn on GPU, an SDPA fallback on CPU, checked against a padded reference). Pretraining masks 15% of tokens, 10% of whole events, and 10% of `(user, key)` groups, then reconstructs each masked value from a **3-view** head — `concat[ẑ_e, z_h(event), z_h(USR)] ∈ ℝ^{3d} → Linear(3d→d)` — scored against the **tied** embedding table.
+
+### The Nemotron variant
+
+By default, high-cardinality text is BPE. The optional **PRAGMA+Nemotron** variant instead emits **one sentinel token** per text field and lets a *frozen* text model embed its raw string; masked text tokens are reconstructed with **MSE** against that vector, so the loss becomes $\mathcal{L} = \text{CE} + \lambda \cdot \text{MSE}$. It's switchable from the data step alone and **off by default** (the BPE path stays byte-identical). To train it on AWS, `pip install -e ".[extras]"` on the instance, then tokenize with `configs/data/tokenizer_nemotron.yaml` before `pretrain` — the text branch is auto-wired. See [the variant page](/docs/concepts/nemotron).
+
+## Prerequisites
+
+<Steps>
+
+<Step>
+
+### An AWS account + the CLI
+
+Install the [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) and configure credentials:
+
+```bash
+aws configure          # access key, secret, default region (e.g. us-east-1), output (json)
+aws sts get-caller-identity   # confirm you're authenticated
+```
+
+</Step>
+
+<Step>
+
+### A GPU quota (do this first — it can take time)
+
+New AWS accounts start with a **zero vCPU quota for G and P instances**, so a GPU launch fails until you raise it. In the [Service Quotas console](https://console.aws.amazon.com/servicequotas/home/services/ec2/quotas/) (EC2), request an increase for:
+
+- **Running On-Demand G and VT instances** — for `g5` / `g6` / `g6e` (this guide's default), or
+- **Running On-Demand P instances** — for `p4d` / `p4de` / `p5`.
+
+Ask for at least the vCPU count of the instance you plan to launch (e.g. 4 for `g6e.xlarge`). Small increases often auto-approve; larger ones go to Support. See [EC2 instance quotas](https://docs.aws.amazon.com/ec2/latest/instancetypes/ec2-instance-quotas.html).
+
+</Step>
+
+<Step>
+
+### A key pair, security group, and S3 access
+
+```bash
+# SSH key pair
+aws ec2 create-key-pair --key-name pragmatiq --query KeyMaterial --output text > pragmatiq.pem
+chmod 600 pragmatiq.pem
+
+# An S3 bucket for datasets, checkpoints, and the model artifact
+aws s3 mb s3://YOUR-pragmatiq-bucket
+```
+
+Create a security group that allows **SSH from your IP only**, and attach an **IAM instance profile** that grants the instance read/write to your bucket (the [EC2 → S3 role pattern](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html); scope it to your bucket rather than `AmazonS3FullAccess` for least privilege). See [security groups](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/creating-security-group.html) and [key pairs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html).
+
+</Step>
+
+</Steps>
+
+## Pick an instance
+
+pragmatiq trains on one GPU and runs on CPU when there isn't one. Right-size to the model — there's no need for an 8-GPU box to train the 10M-parameter `small` config.
+
+| Stage | Instance | Accelerator | When |
+| --- | --- | --- | --- |
+| Smoke / data prep | [`c7i.2xlarge`](https://aws.amazon.com/ec2/instance-types/c7i/) | CPU only | Generate + tokenize, or rehearse end-to-end. No GPU quota needed. |
+| **Single-GPU dev (recommended)** | [`g6e.xlarge`](https://aws.amazon.com/ec2/instance-types/g6e/) | 1× NVIDIA L40S (48 GB) | `small`/`medium` models, bf16 + flash-attn; cheap enough to iterate. |
+| Budget single-GPU | [`g5.xlarge`](https://aws.amazon.com/ec2/instance-types/g5/) / [`g6.xlarge`](https://aws.amazon.com/ec2/instance-types/g6/) | 1× A10G / L4 (24 GB) | Lowest-cost GPU entry; uses the SDPA attention path. |
+| Full scale | [`p4de.24xlarge`](https://aws.amazon.com/ec2/instance-types/p4/) / [`p5.48xlarge`](https://aws.amazon.com/ec2/instance-types/p5/) | 8× A100 80 GB / H100 | The 1B `large` config and multi-GPU/multi-node DDP. |
+
+<Callout type="info" title="Cost & spot">
+Prices move, so size with the [AWS Pricing Calculator](https://calculator.aws/) rather than a number
+printed here. Because pragmatiq checkpoints capture the full training state (and resume bit-exactly),
+training is a good fit for [Spot Instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-savings.html) —
+checkpoint to S3, and a reclaimed instance resumes where it left off. The flash-attn kernel needs an
+Ada/Hopper GPU (L40S, L4, H100); on older cards pragmatiq falls back to PyTorch SDPA automatically.
+</Callout>
+
+## Train on EC2
+
+You have two paths: the **DIY EC2 instance** below (full control, closest to a local workflow), or a managed **SageMaker training job** (the callout) that provisions the box, runs your script, and tears it down for you.
+
+<Callout type="info" title="Managed alternative: a SageMaker training job">
+Instead of SSHing into an instance, hand the run to SageMaker. With the [SageMaker Python SDK
+`PyTorch` estimator](https://docs.aws.amazon.com/sagemaker/latest/dg/data-parallel-framework-estimator.html),
+point `entry_point` at a thin script that calls `api.synthesize` / `api.tokenize` / `api.pretrain`,
+set the instance type (e.g. `ml.g5.2xlarge`), and SageMaker mounts your S3 input channels at
+`/opt/ml/input/data/…`, runs the job, and uploads `/opt/ml/model` back to S3. Turn on
+[managed spot training](https://docs.aws.amazon.com/sagemaker/latest/dg/model-managed-spot-training.html)
+with checkpoints to `/opt/ml/checkpoints` for up to ~90% savings — pragmatiq's bit-exact `--resume`
+makes interruptions safe. [SageMaker Studio](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated.html)
+is the notebook-driven way to launch the same jobs.
+</Callout>
+
+<Steps>
+
+<Step>
+
+### Launch from the Deep Learning AMI
+
+Launch your chosen instance from a current **Deep Learning OSS Nvidia Driver AMI GPU PyTorch (Ubuntu 22.04)** — it ships the NVIDIA driver, CUDA, and a CUDA-enabled PyTorch, so there's nothing to compile. Find the latest AMI id in the [DLAMI release notes](https://docs.aws.amazon.com/dlami/latest/devguide/appendix-ami-release-notes.html), attach your key pair, security group, and the S3 instance profile, and give it a **100–200 GB gp3** root volume for checkpoints and shards ([EBS gp3](https://docs.aws.amazon.com/ebs/latest/userguide/general-purpose.html)).
+
+```bash
+ssh -i pragmatiq.pem ubuntu@<INSTANCE_PUBLIC_IP>
+nvidia-smi                                   # driver + GPU visible
+python -c "import torch; print(torch.__version__, torch.cuda.is_available())"
+```
+
+</Step>
+
+<Step>
+
+### Install pragmatiq
+
+The DLAMI's PyTorch already has CUDA, so install pragmatiq against it (don't reinstall torch):
+
+```bash
+git clone https://github.com/dynamiq-ai/pragmatiq.git && cd pragmatiq
+pip install -e ".[serve]"      # .[serve] adds the ONNX/Triton client used later
+```
+
+</Step>
+
+<Step>
+
+### Generate & tokenize
+
+```bash
+pragmatiq synth generate --out data/synth --n-users 50000 --seed 0 --n-workers 8
+pragmatiq tokenize data/synth --out data/tok --n-workers 8
+```
+
+The generator is **deterministic** (same seed → byte-identical output for any worker count), and the tokenizer fit is worker-count-invariant. See [Generate & tokenize](/docs/tutorials/data-pipeline). To model your own book without moving raw records, `pragmatiq synth calibrate --stats configs/data/aggregates.example.yaml` fits the generator to shareable aggregates.
+
+</Step>
+
+<Step>
+
+### Pretrain
+
+```bash
+pragmatiq pretrain data/tok --name demo --model-size small --config configs/pretrain.yaml
+```
+
+The trainer auto-detects CUDA (**bf16-mixed on GPU**, fp32 on CPU) — identical command either way — and prints a `step, loss, mlm_acc, tokens/s, ETA` heartbeat. For larger books pass `--config auto` to size the batch, gradient accumulation, and schedule from the data and the device; add `--devices N` for multi-GPU Fabric DDP on a `p4de`/`p5`. Checkpoints capture model, both optimizers, scheduler, sampler position, and RNG states, so `--resume auto` survives a Spot reclaim. See [Pretrain (and scale)](/docs/tutorials/pretrain).
+
+</Step>
+
+<Step>
+
+### Embed, probe, fine-tune, and the AML graph
+
+```bash
+pragmatiq embed data/tok --run runs/demo --out embeddings.parquet
+pragmatiq probe data/tok --run runs/demo \
+  --label data/synth/labels/default_12m.parquet --probe-model gbdt
+pragmatiq finetune data/tok --run runs/demo \
+  --label data/synth/labels/default_12m.parquet --config configs/finetune/credit.yaml
+pragmatiq gnn data/tok --run runs/demo \
+  --transfers data/synth/transfers.parquet \
+  --aml-label data/synth/labels/aml.parquet --epochs 150
+```
+
+The probe reports ROC-AUC + PR-AUC against a same-classifier raw-count baseline (histories are truncated at each label's `eval_ts`, so metrics never see the outcome window). See [Embed, probe & fine-tune](/docs/tutorials/evaluate) and the [AML GNN ablation](/docs/tutorials/aml-gnn).
+
+</Step>
+
+<Step>
+
+### Stage artifacts to S3
+
+```bash
+aws s3 sync runs/demo s3://YOUR-pragmatiq-bucket/runs/demo
+aws s3 cp embeddings.parquet s3://YOUR-pragmatiq-bucket/embeddings.parquet
+```
+
+The trained run in S3 is the input to serving. You can now **stop or terminate** the training instance. See [`aws s3 sync`](https://docs.aws.amazon.com/cli/latest/reference/s3/sync.html).
+
+</Step>
+
+</Steps>
+
+## Serve with NVIDIA Triton on Amazon SageMaker
+
+pragmatiq's production serving path is a **Triton python backend running the native varlen PyTorch model** — the exact no-padding forward used in training (see [Serve with Triton](/docs/tutorials/serve)). On AWS, the managed home for that is an [Amazon SageMaker real-time endpoint with the Triton Inference Server](https://docs.aws.amazon.com/sagemaker/latest/dg/triton.html): you bring the Triton model repository, SageMaker handles scaling, health checks, and HTTPS.
+
+<Steps>
+
+<Step>
+
+### Build a SageMaker-Triton image with pragmatiq installed
+
+The stock Triton image can't `import pragmatiq`, so — exactly as [`deploy/triton/Dockerfile`](https://github.com/dynamiq-ai/pragmatiq/blob/main/deploy/triton/Dockerfile) does for local serving — install pragmatiq into Triton's Python. For SageMaker, base the image on the **SageMaker Triton container** so it speaks SageMaker's inference contract (`/ping`, `/invocations`), then push it to [Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html):
+
+```dockerfile
+# Dockerfile.sagemaker — base on the SageMaker Triton DLC for your region/version
+# (see the SageMaker Triton docs for the current image URI), then add pragmatiq.
+FROM <ACCOUNT>.dkr.ecr.<REGION>.amazonaws.com/sagemaker-tritonserver:<TAG>
+RUN pip install --no-cache-dir "pragmatiq[serve] @ git+https://github.com/dynamiq-ai/pragmatiq.git"
+```
+
+```bash
+aws ecr create-repository --repository-name pragmatiq-triton
+# docker build -t pragmatiq-triton -f Dockerfile.sagemaker . && push to ECR (see the ECR docs)
+```
+
+Bake every dependency into the image — SageMaker runs the container read-only, so there's no package install at request time.
+
+</Step>
+
+<Step>
+
+### Package the model repository + run
+
+SageMaker loads a Triton **model repository** from a `model.tar.gz` in S3. Use pragmatiq's committed repository layout ([`deploy/triton/model_repository/pragmatiq_embedder/`](https://github.com/dynamiq-ai/pragmatiq/tree/main/deploy/triton/model_repository)) — the `config.pbtxt` plus `1/model.py` — and include the trained run it should serve:
+
+```bash
+mkdir -p model_repository/pragmatiq_embedder/1
+cp -r deploy/triton/model_repository/pragmatiq_embedder/config.pbtxt model_repository/pragmatiq_embedder/
+cp -r deploy/triton/model_repository/pragmatiq_embedder/1/model.py   model_repository/pragmatiq_embedder/1/
+aws s3 cp s3://YOUR-pragmatiq-bucket/runs/demo model_repository/pragmatiq_embedder/1/run --recursive
+tar -C model_repository -czf model.tar.gz pragmatiq_embedder
+aws s3 cp model.tar.gz s3://YOUR-pragmatiq-bucket/triton/model.tar.gz
+```
+
+</Step>
+
+<Step>
+
+### Create the model, endpoint config, and endpoint
+
+Point a SageMaker **Model** at your ECR image and the S3 artifact, then create an **endpoint** on a GPU instance (`ml.g5.xlarge` is a fine starting point):
+
+```bash
+aws sagemaker create-model --model-name pragmatiq-embedder \
+  --execution-role-arn arn:aws:iam::<ACCOUNT>:role/<SageMakerExecutionRole> \
+  --primary-container 'Image=<ACCOUNT>.dkr.ecr.<REGION>.amazonaws.com/pragmatiq-triton:latest,ModelDataUrl=s3://YOUR-pragmatiq-bucket/triton/model.tar.gz,Environment={SAGEMAKER_TRITON_DEFAULT_MODEL_NAME=pragmatiq_embedder,SAGEMAKER_TRITON_SHM_DEFAULT_BYTE_SIZE=1073741824}'
+
+aws sagemaker create-endpoint-config --endpoint-config-name pragmatiq-embedder \
+  --production-variants VariantName=main,ModelName=pragmatiq-embedder,InstanceType=ml.g5.xlarge,InitialInstanceCount=1
+
+aws sagemaker create-endpoint --endpoint-name pragmatiq-embedder \
+  --endpoint-config-name pragmatiq-embedder
+aws sagemaker wait endpoint-in-service --endpoint-name pragmatiq-embedder
+```
+
+`SAGEMAKER_TRITON_DEFAULT_MODEL_NAME` tells the single-model endpoint which model in the repository to load, and the python backend runs in shared memory, so raise `SAGEMAKER_TRITON_SHM_DEFAULT_BYTE_SIZE` above its 16 MB default. Add [auto-scaling](https://docs.aws.amazon.com/sagemaker/latest/dg/endpoint-auto-scaling.html) once it's live; the [SageMaker Triton guide](https://docs.aws.amazon.com/sagemaker/latest/dg/deploy-models-frameworks-triton.html) has the current container URIs and the execution-role policy.
+
+</Step>
+
+<Step>
+
+### Invoke it
+
+The request body is the **same `records_json` payload** as local Triton — a JSON array of plain user records; the response is the `[n_users, dim]` fp32 embedding matrix. Batching happens *inside* the model (the varlen forward packs all users with no padding), and unseen keys/values map to `[UNK]` rather than raising. The SageMaker Triton container adapts Triton's KServe v2 protocol to SageMaker's `/invocations`, so you POST the same body through the standard `invoke-endpoint`.
+
+```bash
+aws sagemaker-runtime invoke-endpoint --endpoint-name pragmatiq-embedder \
+  --content-type application/json \
+  --body '{"inputs":[{"name":"records_json","shape":[1],"datatype":"BYTES","data":["[{\"user_id\":\"u1\",\"events\":[{\"ts\":1718200000000000,\"source\":\"transaction\",\"fields\":{\"amount\":\"42.50\",\"merchant\":\"TESCO\"}}],\"attributes\":{\"country\":\"GB\"},\"lifelong\":[]}]"]}]}' \
+  out.json && cat out.json
+```
+
+</Step>
+
+</Steps>
+
+<Callout type="info" title="Other serving options">
+Prefer not to use SageMaker? The same image runs anywhere Triton does: a **single EC2 GPU instance**
+(closest to the repo's [`scripts/deploy_serving.sh`](https://github.com/dynamiq-ai/pragmatiq/blob/main/scripts/deploy_serving.sh)
++ `docker compose`), **[Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)**, or
+**Amazon EKS**. SageMaker trades a bit of control for managed scaling, health checks, and HTTPS.
+
+For irregular traffic, SageMaker also offers [async inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html) (queue-based, scales to zero) and [serverless inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html) (pay-per-request) — serverless is **CPU-only**, which suits pragmatiq's CPU forward; real-time is the low-latency GPU default.
+</Callout>
+
+## Clean up
+
+GPU resources bill by the hour — tear down what you're not using:
+
+```bash
+aws sagemaker delete-endpoint --endpoint-name pragmatiq-embedder
+aws sagemaker delete-endpoint-config --endpoint-config-name pragmatiq-embedder
+aws sagemaker delete-model --model-name pragmatiq-embedder
+aws ec2 terminate-instances --instance-ids <INSTANCE_ID>   # if you didn't already
+```
+
+Keep artifacts in S3 (cheap) and delete them when done. Use the [Pricing Calculator](https://calculator.aws/) to estimate before a long run, and prefer Spot + right-sizing for training.
+
+## Where to go next
+
+- [PyTorch on AWS](https://aws.amazon.com/pytorch/) and the [AWS Machine Learning Blog](https://aws.amazon.com/blogs/machine-learning/) — patterns for distributed training and inference.
+- [Deep Learning AMI](https://docs.aws.amazon.com/dlami/latest/devguide/) and [Deep Learning Containers](https://docs.aws.amazon.com/deep-learning-containers/latest/devguide/what-is-dlc.html) — the supported PyTorch/CUDA images.
+- [NVIDIA Triton on SageMaker](https://docs.aws.amazon.com/sagemaker/latest/dg/triton.html) — multi-model endpoints, autoscaling, and TensorRT.
+- For very large books, [Amazon FSx for Lustre](https://docs.aws.amazon.com/fsx/latest/LustreGuide/what-is.html) removes the S3 download bottleneck across multi-node runs. AWS [Trainium](https://aws.amazon.com/ai/machine-learning/trainium/) is a cost lever for training via PyTorch/Neuron — note it's not a drop-in for CUDA/flash-attn.
+
+Locally, the same flow is [Quickstart](/docs/get-started/quickstart) → [Pretrain](/docs/tutorials/pretrain) → [Serve](/docs/tutorials/serve).

--- a/website/content/docs/tutorials/meta.json
+++ b/website/content/docs/tutorials/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Tutorials",
-  "pages": ["data-pipeline", "pretrain", "evaluate", "serve", "aml-gnn", "bring-your-own-data"]
+  "pages": ["data-pipeline", "pretrain", "evaluate", "serve", "aws", "aml-gnn", "bring-your-own-data"]
 }

--- a/website/content/docs/tutorials/pretrain.mdx
+++ b/website/content/docs/tutorials/pretrain.mdx
@@ -85,4 +85,7 @@ is a turnkey path to validate on a rented A100/H100: it provisions a pod, syncs 
 SSH, installs, and runs the GPU end-to-end pipeline (including auto-config, the Nemotron
 variant, serving, and the full-scale gates).
 
+On a cloud provider, see [Run pragmatiq on AWS](/docs/tutorials/aws) for the full path on an EC2
+GPU instance (Deep Learning AMI) with serving on Amazon SageMaker.
+
 Next: [Embed & evaluate](/docs/tutorials/evaluate).


### PR DESCRIPTION
## Summary

Adds one SEO-oriented, end-to-end tutorial — **Run pragmatiq on AWS** — to the docs site.

- **Train on EC2**: launch from the AWS Deep Learning AMI, run the full pipeline (generate → tokenize → pretrain → embed → probe → fine-tune → AML GNN), stage artifacts to S3.
- **Serve on SageMaker**: build the pragmatiq Triton image → ECR → an Amazon SageMaker real-time endpoint, invoked with the same `records_json` body as the local Triton path.
- Prerequisites cover the GPU-quota gotcha, key pair / security group / IAM-for-S3; a right-sized instance table; cost + teardown; and a "scale further" link list. One light "Dynamiq is an AWS Partner" callout.

Reuses the exact commands from the existing tutorials. No library or pipeline changes; no AWS resources provisioned. Pricing links the AWS calculator (not hard-coded — rates move), and every AWS claim links an official doc.

## Files
- `website/content/docs/tutorials/aws.mdx` (new)
- `website/content/docs/tutorials/meta.json` — adds `aws` to the tutorials nav
- `website/content/docs/tutorials/pretrain.mdx` — cross-link from "Renting a GPU"

## Verification
- `pnpm build` clean; the page prerenders at `/docs/tutorials/aws` and is in the nav + sitemap + OG images.
- `scripts/docs_drift_check.py` green (no `facts.json` change).
- External AWS URLs spot-checked (200).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no library, pipeline, or infrastructure code modifications.
> 
> **Overview**
> Adds a new **Run pragmatiq on AWS** tutorial that walks through **EC2 training** (DLAMI, same CLI pipeline as local docs, artifacts to S3) and **SageMaker real-time serving** (custom Triton+pragmatiq image in ECR, `model.tar.gz`, `records_json` invocations). The page also covers prerequisites (GPU quotas, IAM/S3), instance sizing, Spot/checkpointing, optional SageMaker training jobs, cleanup, and reuses existing interactive docs components where relevant.
> 
> **Navigation:** `aws` is inserted in the tutorials sidebar (`meta.json`). **Pretrain** gains a short cross-link from “Renting a GPU” to the AWS guide alongside the existing RunPod script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bad35b46b9e68dbaf07f06ac29156da830e1d65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->